### PR TITLE
Improve help documentation (C-h m)

### DIFF
--- a/typed-clojure-mode.el
+++ b/typed-clojure-mode.el
@@ -42,7 +42,11 @@
 
 ;;;###autoload
 (define-minor-mode typed-clojure-mode
-  "Typed Clojure minor mode"
+  "The official minor mode for editing Typed Clojure. Provides
+namespace typechecking, error navigation, display of type data,
+and annotation snippets.
+
+\\{typed-clojure-mode-map}"
   :group 'typed-clojure
   :lighter " Typed"
   :keymap typed-clojure-mode-map)


### PR DESCRIPTION
Now the emacs help looks like this but with better spacing:

<pre>
Typed-Clojure minor mode (indicator Typed):
The official minor mode for editing Typed Clojure. Provides
namespace typechecking, error navigation, display of type data,
and annotation snippets.

key             binding
---             -------

C-c     Prefix Command

C-c C-a     Prefix Command
C-c C-x     Prefix Command

C-c C-a f   typed-clojure-ann-form
C-c C-a v   typed-clojure-ann-var

C-c C-x f   typed-clojure-check-form
C-c C-x n   typed-clojure-check-ns
</pre>
